### PR TITLE
fix: avoid crash of timepicker when 0 is manually typed into hours

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opsramp/react-date-time-range-picker",
-  "version": "1.0.33",
+  "version": "1.0.34",
   "description": "A React component for choosing date and time ranges.",
   "main": "dist/index.js",
   "scripts": {

--- a/src/components/Calendar.js
+++ b/src/components/Calendar.js
@@ -266,7 +266,9 @@ class Calendar extends PureComponent {
                   type={showTime ? 'time' : 'hidden'}
                   value={this.formatTimeDisplay(range.startDate)}
                   onChange={evt => {
-                    this.updateTime(evt.target.value, range.startDate, range.endDate, 0);
+                    if (evt.target.value !== '') {
+                      this.updateTime(evt.target.value, range.startDate, range.endDate, 0);
+                    }
                   }}
                   required={showTime ? true : false}
                 />
@@ -286,7 +288,9 @@ class Calendar extends PureComponent {
                   type={showTime ? 'time' : 'hidden'}
                   value={this.formatTimeDisplay(range.endDate)}
                   onChange={evt => {
-                    this.updateTime(evt.target.value, range.startDate, range.endDate, 1);
+                    if (evt.target.value !== '') {
+                      this.updateTime(evt.target.value, range.startDate, range.endDate, 1);
+                    }
                   }}
                   required={showTime ? true : false}
                 />


### PR DESCRIPTION
…ction of input type="time"

## Types of changes

What types of changes does your code introduce?

_Put an `x` in the boxes that apply_

- [X ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Description
When running on new Storybook and React, I have observed an issue, when the user types "0" into the hours section of <input type="time> time picker component crashes. Proposed protection allows to ignore such cases. As when "0" is typed - `event.target.value` is `""` empty string

> Related Issue: #xxx